### PR TITLE
Added `.cshtml` to `Settings.SourceFileExtensions`

### DIFF
--- a/MyZeroTool/Settings.cs
+++ b/MyZeroTool/Settings.cs
@@ -18,7 +18,7 @@ namespace MyZeroTool
 
         public static string[] SourceFileExtensions { get; set; } =
         {
-            ".html", ".js", ".ts",
+            ".html", ".js", ".ts", "cshtml",
             ".cs", ".csproj", ".sln", ".config", ".user",
             ".json", ".txt", ".ps1", ".yml", ".nswag", ".conf", "Dockerfile", ".gitignore"
         };


### PR DESCRIPTION
`*.cshtml` files have references to project objects, for example `@using MyCompanyName.AbpZeroTemplate.Web.Areas.AppAreaName.Startup`

This change allows your tool to modify those files to match the new namespaces